### PR TITLE
Adding grav-plugin-webpacker to dependencies

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -27,6 +27,7 @@
     "sort-css-media-queries": "1.3.4",
     "stylelint-config-standard": "18.2.0",
     "stylelint-order": "0.8.1",
-    "stylelint-scss": "3.1.0"
+    "stylelint-scss": "3.1.0",
+    "grav-plugin-webpacker": "^1.4.0"
   }
 }


### PR DESCRIPTION
I needed to add it otherwise It couldn't run the webpack script.